### PR TITLE
Fixed the import of PyAny to correctly create regularizers, restructu…

### DIFF
--- a/src/regularizers.jl
+++ b/src/regularizers.jl
@@ -1,21 +1,18 @@
 module Regularizers
 
-import PyCall: PyObject, pycall
+import PyCall: PyObject, pycall, PyAny
 
 import ..Keras
 import ..Keras: PyDoc
 
-const keras_regularizers = [ "WeightRegularizer", "ActivityRegularizer" ]
-const keras_regularizer_shortcuts = [
+const keras_regularizer_classes = [ "Regularizer", "L1L2"]
+const keras_regularizer_aliases = [
     "l1",
     "l2",
-    "l1l2",
-    "activity_l1",
-    "activity_l2",
-    "activity_l1l2",
+    "l1_l2",
 ]
 
-for r in keras_regularizers
+for r in keras_regularizer_classes
     reg_name = Symbol(r)
 
     @eval begin
@@ -33,7 +30,7 @@ for r in keras_regularizers
     end
 end
 
-for r in keras_regularizer_shortcuts
+for r in keras_regularizer_aliases
     rf = Symbol(r)
 
     @eval begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -174,6 +174,18 @@ rmse(actual, pred) = sqrt(mse(actual, pred))
         end
     end
 
+    @testset "Regularizers" begin
+        @testset "Regularizer classes: $rc" for rc in Keras.Regularizers.keras_regularizer_classes
+            q = getfield(Keras.Regularizers, Symbol(rc))()
+            @test isa(q.obj, PyCall.PyObject)
+        end
+
+        @testset "Creating $reg regularizer" for reg in Keras.Regularizers.keras_regularizer_aliases
+            q = getfield(Keras.Regularizers, Symbol(reg))()
+            @test isa(q, PyCall.PyObject)
+        end
+    end
+
     @testset "PyDoc" begin
         output = sprint(show, Keras.PyDoc(Keras._models, :Sequential))
         @test startswith(output, "Linear stack of layers.")


### PR DESCRIPTION
This PR addresses some issues appearing with the Regularizers.

- `PyAny` needs to be imported in order to correctly create regularizers as in line 41 of `src/regularizers.jl`. 

- Some restructuring of the available classes (`WeightRegularizer` and `ActivityRegularizer` are not available) and aliases. 

- Added corresponding tests.